### PR TITLE
Fix url builder for stackbit pull handler

### DIFF
--- a/stackbit-pull.js
+++ b/stackbit-pull.js
@@ -15,9 +15,10 @@ function pull(stackbitPullApiUrl, apiKey) {
         const body = JSON.stringify({apiKey: apiKey});
 
         const options = {
-            host: urlObject.host,
+            hostname: urlObject.hostname,
             path: urlObject.path,
             protocol: urlObject.protocol,
+            port: urlObject.port || 443,
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
Separated host to hostname & port for supporting `https://localhost:8000` (https on non standard port)